### PR TITLE
Fix overly match-happy sed commands

### DIFF
--- a/bump_version.sh
+++ b/bump_version.sh
@@ -11,6 +11,9 @@ VERSION_FILE=eal/_version.py
 HELP_INFORMATION="bump_version.sh (show|major|minor|patch|prerelease|build|finalize)"
 
 old_version=$(sed -n "s/^__version__ = \"\(.*\)\"$/\1/p" $VERSION_FILE)
+# Comment out periods so they are interpreted as periods and don't
+# just match any character
+old_version_regex=${old_version//\./\\\.}
 
 if [ $# -ne 1 ]; then
   echo "$HELP_INFORMATION"
@@ -22,7 +25,7 @@ else
       # A temp file is used to provide compatability with macOS development
       # as a result of macOS using the BSD version of sed
       tmp_file=/tmp/version.$$
-      sed "s/$old_version/$new_version/" $VERSION_FILE > $tmp_file
+      sed "s/$old_version_regex/$new_version/" $VERSION_FILE > $tmp_file
       mv $tmp_file $VERSION_FILE
       git add $VERSION_FILE
       git commit -m"Bump version from $old_version to $new_version"
@@ -34,10 +37,10 @@ else
       # A temp file is used to provide compatability with macOS development
       # as a result of macOS using the BSD version of sed
       tmp_file=/tmp/version.$$
-      sed "s/$old_version/$new_version/" $VERSION_FILE > $tmp_file
+      sed "s/$old_version_regex/$new_version/" $VERSION_FILE > $tmp_file
       mv $tmp_file $VERSION_FILE
       git add $VERSION_FILE
-      git commit -m"Bump version from $old_version to $new_version"
+      git commit -m"Finalize version from $old_version to $new_version"
       git push
       ;;
     show)


### PR DESCRIPTION
## 🗣 Description ##

This pull request tightens a few `sed` commands so that their regexes do not inadvertently match when they should not. 

## 💭 Motivation and context ##

We saw in cisagov/postfix-docker#47 that the `sed` commands in the `bump_version.sh` script could inadvertently match the CC0 version in the `README.md` file.  This change escapes the periods in the version before passing it on to `sed` so that they only match periods and not just any character.

## 🧪 Testing ##

I tested locally and verified that with these changes the situation that arose in cisagov/postfix-docker#47 does not occur.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.